### PR TITLE
✨ Unify artifact versioning

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'application'
 
+apply from: rootProject.file('version.gradle')
+
 group 'jp.co.panpanini'
-version '0.1-SNAPSHOT'
+version "${versionName()}"
 
 sourceCompatibility = 1.8
 

--- a/retrofit-converter/build.gradle
+++ b/retrofit-converter/build.gradle
@@ -35,7 +35,7 @@ compileTestKotlin {
 artifactoryPublish {
     groupId = 'jp.co.panpanini'
     artifactId = 'protok-retrofit-converter'
-    publishVersion = "0.0.30"
+    publishVersion = versionName
     artifactoryUrl = artifactoryUrl
     artifactoryRepo = artifactoryRepo
     artifactoryUser = artifactoryUsername

--- a/retrofit-converter/build.gradle
+++ b/retrofit-converter/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'guru.stefma.artifactorypublish'
 
 sourceCompatibility = 1.8
 
-apply from:"${project.rootDir}/version.gradle"
+apply from: rootProject.file('version.gradle')
 
 repositories {
     mavenCentral()

--- a/retrofit-converter/build.gradle
+++ b/retrofit-converter/build.gradle
@@ -34,7 +34,7 @@ compileTestKotlin {
 artifactoryPublish {
     groupId = 'jp.co.panpanini'
     artifactId = 'protok-retrofit-converter'
-    publishVersion = versionName
+    publishVersion = versionName()
     artifactoryUrl = artifactoryUrl
     artifactoryRepo = artifactoryRepo
     artifactoryUser = artifactoryUsername

--- a/retrofit-converter/build.gradle
+++ b/retrofit-converter/build.gradle
@@ -2,9 +2,6 @@ apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'guru.stefma.artifactorypublish'
 
-group 'jp.co.panpanini'
-version '0.1-SNAPSHOT'
-
 sourceCompatibility = 1.8
 
 apply from:"${project.rootDir}/version.gradle"

--- a/retrofit-converter/build.gradle
+++ b/retrofit-converter/build.gradle
@@ -7,6 +7,8 @@ version '0.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
+apply from:"${project.rootDir}/version.gradle"
+
 repositories {
     mavenCentral()
     maven { url "https://kotlin.bintray.com/kotlinx" }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'guru.stefma.artifactorypublish'
 
 sourceCompatibility = 1.8
 
-apply from:"${project.rootDir}/version.gradle"
+apply from: rootProject.file('version.gradle')
 
 repositories {
     mavenCentral()

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -34,7 +34,7 @@ jar {
 artifactoryPublish {
     groupId = 'jp.co.panpanini'
     artifactId = 'protok-runtime'
-    publishVersion = versionName
+    publishVersion = versionName()
     artifactoryUrl = artifactoryUrl
     artifactoryRepo = artifactoryRepo
     artifactoryUser = artifactoryUsername

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -32,7 +32,7 @@ jar {
 artifactoryPublish {
     groupId = 'jp.co.panpanini'
     artifactId = 'protok-runtime'
-    publishVersion = "0.0.9"
+    publishVersion = versionName
     artifactoryUrl = artifactoryUrl
     artifactoryRepo = artifactoryRepo
     artifactoryUser = artifactoryUsername

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'guru.stefma.artifactorypublish'
 
 sourceCompatibility = 1.8
 
+apply from:"${project.rootDir}/version.gradle"
+
 repositories {
     mavenCentral()
     maven { url "https://kotlin.bintray.com/kotlinx" }

--- a/version.gradle
+++ b/version.gradle
@@ -1,0 +1,40 @@
+ext.versionFilePath = "${project.rootDir}/version.properties"
+
+task bumpMajor {
+    doLast {
+        ant.propertyfile(file: versionFilePath) {
+            entry(key: 'major', type: 'int', operation: '+', value: 1)
+            entry(key: 'minor', type: 'int', operation: '=', value: 0)
+            entry(key: 'patch', type: 'int', operation: '=', value: 0)
+        }
+    }
+}
+
+task bumpMinor {
+    doLast {
+        ant.propertyfile(file: versionFilePath) {
+            entry(key: 'minor', type: 'int', operation: '+', value: 1)
+            entry(key: 'patch', type: 'int', operation: '=', value: 0)
+        }
+    }
+}
+
+task bumpPatch {
+    doLast {
+        ant.propertyfile(file: versionFilePath) {
+            entry(key: 'patch', type: 'int', operation: '+', value: 1)
+        }
+    }
+}
+
+def getVersionProps() {
+    def versionPropsFile = file(versionFilePath)
+    def props = new Properties()
+    props.load(new FileInputStream(versionPropsFile))
+    return props
+}
+
+ext.versionName = {
+    def props = getVersionProps()
+    return "${props['major']}.${props['minor']}.${props['patch']}"
+}

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,4 @@
+#Fri, 1 Mar 2019 12:31:29 -0800
+major=0
+minor=1
+patch=0


### PR DESCRIPTION
To make using the library easier for end users, artifact versions should be unified.

closes #7 