### PR TITLE
🐛 fix(Use HashMap instead of MessageMap): n/a

### DIFF
--- a/library/src/main/kotlin/jp/co/panpanini/MessageCompanionGenerator.kt
+++ b/library/src/main/kotlin/jp/co/panpanini/MessageCompanionGenerator.kt
@@ -140,7 +140,7 @@ class MessageCompanionGenerator(private val file: File, private val kotlinTypeMa
 
     private val File.Field.Standard.unmarshalVarDone get() =
         when {
-            map -> "pbandk.MessageMap.Builder.fixed($kotlinFieldName)"
+            map -> "HashMap(pbandk.MessageMap.Builder.fixed($kotlinFieldName))"
             repeated -> "pbandk.ListWithSize.Builder.fixed($kotlinFieldName).list"
             else -> kotlinFieldName
         }

--- a/library/src/test/resources/kotlin/Mappy.kt
+++ b/library/src/test/resources/kotlin/Mappy.kt
@@ -158,7 +158,7 @@ data class Mappy(
             while (true) {
                 when (protoUnmarshal.readTag()) {
                     0 -> return Mappy(id,
-                            pbandk.MessageMap.Builder.fixed(things), protoUnmarshal.unknownFields())
+                            HashMap(pbandk.MessageMap.Builder.fixed(things)), protoUnmarshal.unknownFields())
                     10 -> id = protoUnmarshal.readString()
                     18 -> things = protoUnmarshal.readMap(things, api.Mappy.ThingsEntry.Companion,
                             true)


### PR DESCRIPTION
MessageMap does not implement Serializable, and so will crash if you attempt to parcel it