### PR TITLE
Replace pbandk.Sizer with local implementation

### DIFF
--- a/library/src/main/kotlin/jp/co/panpanini/MessageGenerator.kt
+++ b/library/src/main/kotlin/jp/co/panpanini/MessageGenerator.kt
@@ -6,7 +6,9 @@ import com.improve_future.case_changer.toCamelCase
 import com.improve_future.case_changer.toSnakeCase
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import pbandk.*
+import pbandk.Marshaller
+import pbandk.UnknownField
+import pbandk.Unmarshaller
 import pbandk.gen.File
 import java.io.Serializable
 
@@ -521,7 +523,7 @@ class MessageGenerator(private val file: File, private val kotlinTypeMappings: M
     }
 
     private fun File.Field.Standard.sizeExpression(): CodeBlock {
-        val sizer = ClassName("pbandk", "Sizer")
+        val sizer = Sizer::class
         val codeBlock = CodeBlock.builder()
 
         when {

--- a/library/src/test/resources/kotlin/Item.kt
+++ b/library/src/test/resources/kotlin/Item.kt
@@ -24,7 +24,7 @@ data class Item(@JvmField val id: String = "", val unknownFields: Map<Int, Unkno
     fun Item.protoSizeImpl(): Int {
         var protoSize = 0
         if (id != DEFAULT_ID) {
-            protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(id)
+            protoSize += jp.co.panpanini.Sizer.tagSize(1) + jp.co.panpanini.Sizer.stringSize(id)
         }
         protoSize += unknownFields.entries.sumBy { it.value.size() }
         return protoSize

--- a/library/src/test/resources/kotlin/Mappy.kt
+++ b/library/src/test/resources/kotlin/Mappy.kt
@@ -28,10 +28,10 @@ data class Mappy(
     fun Mappy.protoSizeImpl(): Int {
         var protoSize = 0
         if (id != DEFAULT_ID) {
-            protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(id)
+            protoSize += jp.co.panpanini.Sizer.tagSize(1) + jp.co.panpanini.Sizer.stringSize(id)
         }
         if (things.isNotEmpty()) {
-            protoSize += pbandk.Sizer.mapSize(2, things, api.Mappy::ThingsEntry)
+            protoSize += jp.co.panpanini.Sizer.mapSize(2, things, api.Mappy::ThingsEntry)
         }
         protoSize += unknownFields.entries.sumBy { it.value.size() }
         return protoSize
@@ -83,10 +83,12 @@ data class Mappy(
         fun ThingsEntry.protoSizeImpl(): Int {
             var protoSize = 0
             if (key != DEFAULT_KEY) {
-                protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(key)
+                protoSize += jp.co.panpanini.Sizer.tagSize(1) +
+                        jp.co.panpanini.Sizer.stringSize(key)
             }
             if (value != DEFAULT_VALUE) {
-                protoSize += pbandk.Sizer.tagSize(2) + pbandk.Sizer.messageSize(value)
+                protoSize += jp.co.panpanini.Sizer.tagSize(2) +
+                        jp.co.panpanini.Sizer.messageSize(value)
             }
             protoSize += unknownFields.entries.sumBy { it.value.size() }
             return protoSize

--- a/library/src/test/resources/kotlin/OneOfTest.kt
+++ b/library/src/test/resources/kotlin/OneOfTest.kt
@@ -31,22 +31,22 @@ data class OneOfTest(@JvmField val oneofField: OneofField = OneofField.NotSet, v
         if (oneofField !is OneofField.NotSet) {
             protoSize += oneofField.run {
                 when (this) {
-                    is OneofField.OneofUint32 -> pbandk.Sizer.tagSize(111) +
-                            pbandk.Sizer.uInt32Size(oneofUint32)
-                    is OneofField.OneofString -> pbandk.Sizer.tagSize(113) +
-                            pbandk.Sizer.stringSize(oneofString)
-                    is OneofField.OneofBytes -> pbandk.Sizer.tagSize(114) +
-                            pbandk.Sizer.bytesSize(oneofBytes)
-                    is OneofField.OneofBool -> pbandk.Sizer.tagSize(115) +
-                            pbandk.Sizer.boolSize(oneofBool)
-                    is OneofField.OneofUint64 -> pbandk.Sizer.tagSize(116) +
-                            pbandk.Sizer.uInt64Size(oneofUint64)
-                    is OneofField.OneofFloat -> pbandk.Sizer.tagSize(117) +
-                            pbandk.Sizer.floatSize(oneofFloat)
-                    is OneofField.OneofDouble -> pbandk.Sizer.tagSize(118) +
-                            pbandk.Sizer.doubleSize(oneofDouble)
-                    is OneofField.OneofItem -> pbandk.Sizer.tagSize(119) +
-                            pbandk.Sizer.messageSize(oneofItem)
+                    is OneofField.OneofUint32 -> jp.co.panpanini.Sizer.tagSize(111) +
+                            jp.co.panpanini.Sizer.uInt32Size(oneofUint32)
+                    is OneofField.OneofString -> jp.co.panpanini.Sizer.tagSize(113) +
+                            jp.co.panpanini.Sizer.stringSize(oneofString)
+                    is OneofField.OneofBytes -> jp.co.panpanini.Sizer.tagSize(114) +
+                            jp.co.panpanini.Sizer.bytesSize(oneofBytes)
+                    is OneofField.OneofBool -> jp.co.panpanini.Sizer.tagSize(115) +
+                            jp.co.panpanini.Sizer.boolSize(oneofBool)
+                    is OneofField.OneofUint64 -> jp.co.panpanini.Sizer.tagSize(116) +
+                            jp.co.panpanini.Sizer.uInt64Size(oneofUint64)
+                    is OneofField.OneofFloat -> jp.co.panpanini.Sizer.tagSize(117) +
+                            jp.co.panpanini.Sizer.floatSize(oneofFloat)
+                    is OneofField.OneofDouble -> jp.co.panpanini.Sizer.tagSize(118) +
+                            jp.co.panpanini.Sizer.doubleSize(oneofDouble)
+                    is OneofField.OneofItem -> jp.co.panpanini.Sizer.tagSize(119) +
+                            jp.co.panpanini.Sizer.messageSize(oneofItem)
                     else -> 0
                 }
             }

--- a/library/src/test/resources/kotlin/Thing.kt
+++ b/library/src/test/resources/kotlin/Thing.kt
@@ -24,7 +24,7 @@ data class Thing(@JvmField val id: String = "", val unknownFields: Map<Int, Unkn
     fun Thing.protoSizeImpl(): Int {
         var protoSize = 0
         if (id != DEFAULT_ID) {
-            protoSize += pbandk.Sizer.tagSize(1) + pbandk.Sizer.stringSize(id)
+            protoSize += jp.co.panpanini.Sizer.tagSize(1) + jp.co.panpanini.Sizer.stringSize(id)
         }
         protoSize += unknownFields.entries.sumBy { it.value.size() }
         return protoSize

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     api 'com.github.panpanini.pb-and-k:protoc-gen-kotlin-jvm:0.4.0'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile('com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0')
+    testCompile("org.assertj:assertj-core:3.11.1")
 }
 
 compileKotlin {

--- a/runtime/src/main/kotlin/Sizer.kt
+++ b/runtime/src/main/kotlin/Sizer.kt
@@ -1,0 +1,80 @@
+package jp.co.panpanini
+
+import com.google.protobuf.CodedOutputStream
+import pbandk.ByteArr
+
+object Sizer {
+    fun tagSize(fieldNum: Int): Int {
+        return uInt32Size(fieldNum shl 3)
+    }
+
+    fun int32Size(value: Int): Int {
+        return if (value >= 0) uInt32Size(value) else 10
+    }
+
+    fun uInt32Size(value: Int): Int {
+        return when {
+            value and (0.inv() shl 7) == 0 -> 1
+            value and (0.inv() shl 14) == 0 -> 2
+            value and (0.inv() shl 21) == 0 -> 3
+            value and (0.inv() shl 28) == 0 -> 4
+            else -> 5
+        }
+    }
+
+    fun enumSize(value: Enum<*>): Int {
+        return int32Size(value.ordinal)
+    }
+
+    fun messageSize(value: Message<*>) : Int {
+        return uInt32Size(value.protoSize) + value.protoSize
+    }
+
+    fun <T> packedRepeatedSize(list: List<T>, sizingFunction: (T) -> Int): Int {
+        val protoSize = list.sumBy(sizingFunction)
+        return uInt32Size(protoSize) + protoSize
+    }
+
+    fun <K, V, T : Message<T>> mapSize(
+            fieldNumber: Int,
+            map: Map<K, V>,
+            createEntry: (K, V) -> T
+    ) = tagSize(fieldNumber).let { tagSize ->
+        map.entries.sumBy { entry ->
+            val message = entry as? Message<*> ?: createEntry(entry.key, entry.value)
+
+            tagSize + uInt32Size(message.protoSize) + message.protoSize
+        }
+    }
+
+    fun int64Size(value: Long) = uInt64Size(value)
+
+    fun uInt64Size(value: Long) = CodedOutputStream.computeUInt64SizeNoTag(value)
+
+    fun bytesSize(value: ByteArray) = uInt32Size(value.size) + value.size
+
+    fun bytesSize(value: ByteArr) = bytesSize(value.array)
+
+    fun sInt32Size(value: Int) = uInt32Size(value.zigZagEncode())
+
+    fun sInt64Size(value: Long) = uInt64Size(value.zigZagEncode())
+
+    fun doubleSize(value: Double) = 8
+
+    fun floatSize(value: Float) = 4
+
+    fun fixed32Size(value: Int) = 4
+
+    fun fixed64Size(value: Long) = 8
+
+    fun sFixed32Size(value: Int) = 4
+
+    fun sFixed64Size(value: Long) = 8
+
+    fun boolSize(value: Boolean) = 1
+
+    fun stringSize(value: String) = CodedOutputStream.computeStringSizeNoTag(value)
+
+    private fun Int.zigZagEncode() = (this shl 1) xor (this shr 31)
+    private fun Long.zigZagEncode() = (this shl 1) xor (this shr 63)
+}

--- a/runtime/src/test/kotlin/SizerTest.kt
+++ b/runtime/src/test/kotlin/SizerTest.kt
@@ -265,37 +265,37 @@ class SizerTest {
 
     @Test
     fun `doubleSize should equal 8`() {
-        assertThat(target.doubleSize()).isEqualTo(8)
+        assertThat(target.doubleSize(1.0)).isEqualTo(8)
     }
 
     @Test
     fun `floatSize should equal 4`() {
-        assertThat(target.floatSize()).isEqualTo(4)
+        assertThat(target.floatSize(1f)).isEqualTo(4)
     }
 
     @Test
     fun `fixed32Size should equal 4`() {
-        assertThat(target.fixed32Size()).isEqualTo(4)
+        assertThat(target.fixed32Size(1)).isEqualTo(4)
     }
 
     @Test
     fun `fixed64Size should equal 8`() {
-        assertThat(target.fixed64Size()).isEqualTo(8)
+        assertThat(target.fixed64Size(1L)).isEqualTo(8)
     }
 
     @Test
     fun `sFixed32Size should equal 4`() {
-        assertThat(target.sFixed32Size()).isEqualTo(4)
+        assertThat(target.sFixed32Size(1)).isEqualTo(4)
     }
 
     @Test
     fun `sFixed64Size should equal 8`() {
-        assertThat(target.sFixed64Size()).isEqualTo(8)
+        assertThat(target.sFixed64Size(1L)).isEqualTo(8)
     }
 
     @Test
     fun `boolSize should equal 1`() {
-        assertThat(target.boolSize()).isEqualTo(1)
+        assertThat(target.boolSize(true)).isEqualTo(1)
     }
 
     @Test

--- a/runtime/src/test/kotlin/SizerTest.kt
+++ b/runtime/src/test/kotlin/SizerTest.kt
@@ -1,0 +1,304 @@
+import com.nhaarman.mockitokotlin2.*
+import jp.co.panpanini.Message
+import jp.co.panpanini.Sizer
+import org.assertj.core.api.Assertions.*
+import org.junit.Test
+
+import org.mockito.ArgumentMatchers.anyInt
+
+class SizerTest {
+
+    private var target: Sizer = Sizer
+
+    @Test
+    fun `tagSize should call uInt32Size with left shifted input`() {
+        val input = 100
+        target = spy(target)
+
+        target.tagSize(input)
+
+        verify(target).uInt32Size(input shl 3)
+    }
+
+    @Test
+    fun `int32Size should return 10 if input is less than 0`() {
+        val input = -1
+
+        val result = target.int32Size(input)
+
+        assertThat(result).isEqualTo(10)
+    }
+
+    @Test
+    fun `int32Size should call uInt32Size if input is equal to 0`() {
+        val input = 0
+        target = spy(target)
+
+        target.int32Size(input)
+
+        verify(target).uInt32Size(input)
+
+    }
+
+    @Test
+    fun `int32Size should call uInt32Size if input is greater than 0`() {
+        val input = 1
+        target = spy(target)
+
+        target.int32Size(input)
+
+        verify(target).uInt32Size(input)
+    }
+
+    @Test
+    fun `uInt32Size should return 1 when input is less than 7 bits long`() {
+        val input = 127
+        val expected = 1
+
+        val result = target.uInt32Size(input)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `uInt32Size should return 2 when input is more than 7 bits and less than 14 bits long`() {
+        val input = 16383
+        val expected = 2
+
+        val result = target.uInt32Size(input)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `uInt32Size should return 3 when input is more than 14 bits and less than 21 bits long`() {
+        val input = 2097151
+        val expected = 3
+
+        val result = target.uInt32Size(input)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `uInt32Size should return 4 when input is more than 21 bits and less than 28 bits long`() {
+        val input = 268435455
+        val expected = 4
+
+        val result = target.uInt32Size(input)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `uInt32Size should return 5 when input is more than 28 bits long`() {
+        val input = 268435456
+        val expected = 5
+
+        val result = target.uInt32Size(input)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `enumSize should call int32Size`() {
+        val input: Enum<*> = mock {
+            whenever(mock.ordinal).thenReturn(1)
+        }
+        target = spy(target)
+
+        target.enumSize(input)
+
+        verify(target).int32Size(input.ordinal)
+    }
+
+    @Test
+    fun `messageSize should call uInt32Size with the message protoSize`() {
+        val protoSize = 10
+        val input: Message<*> = mock {
+            whenever(mock.protoSize).thenReturn(protoSize)
+        }
+        target = spy(target)
+
+        target.messageSize(input)
+
+        verify(target).uInt32Size(protoSize)
+    }
+
+    @Test
+    fun `messageSize should return the protosize + uInt32Size of the protoSize`() {
+        val protoSize = 10
+        val sizeOfProtoSize = 1 // less than 128 == 1 byte
+        val input: Message<*> = mock {
+            whenever(mock.protoSize).thenReturn(protoSize)
+        }
+
+        val result = target.messageSize(input)
+
+        assertThat(result).isEqualTo(protoSize + sizeOfProtoSize)
+    }
+
+    @Test
+    fun `packedRepeatedSize should return 1 for an empty list`() {
+        val input: List<Int> = listOf()
+        val sizingFunction: (Int) -> Int = {
+            target.int32Size(it)
+        }
+
+        val result = target.packedRepeatedSize(input, sizingFunction)
+
+        assertThat(result).isEqualTo(1)
+    }
+
+    @Test
+    fun `packedRepeatedSize should call sizingFunction to find size of items`() {
+        val input: List<Int> = listOf(1)
+        val sizingFunction: (Int) -> Int = mock {
+            whenever(mock.invoke(anyInt())).thenReturn(1)
+        }
+
+        target.packedRepeatedSize(input, sizingFunction)
+
+        verify(sizingFunction).invoke(1)
+    }
+
+    @Test
+    fun `packedRepeatedSize should return the value of sizingFunction for each item, and add the size of the protoSize`() {
+        val input: List<Int> = listOf(127, 16383, 2097151) // int32Size = 1, 2, 3
+        val protoSize = 1
+        val sizingFunction: (Int) -> Int = {
+            target.int32Size(it)
+        }
+
+        val result = target.packedRepeatedSize(input, sizingFunction)
+
+        assertThat(result).isEqualTo(1 + 2 + 3 + protoSize)
+    }
+
+    @Test
+    fun `mapSize should call tagSize with the fieldNumber`() {
+        val fieldNumber = 1
+        val map: Map<String, String> = mock { }
+        val createEntry: (String, String) -> Nothing = mock { }
+        target = spy(target)
+
+        target.mapSize(fieldNumber, map, createEntry)
+
+        verify(target).tagSize(fieldNumber)
+    }
+
+    @Test
+    fun `mapSize should sum all entries when map contains messages`() {
+        abstract class MapEntry<T: Message<T>>: Message<T>, Map.Entry<Int, T>
+        val fieldNumber = 1
+
+        val protoSize = 10
+        val sizeOfProtoSize = 1 // less than 128 == 1 byte
+        val input: MapEntry<*> = mock {
+            whenever(mock.protoSize).thenReturn(protoSize)
+        }
+
+        val map: Map<Int, Message<*>> = mock {
+            whenever(mock.entries).thenReturn(setOf(input))
+        }
+        val createEntry: (Int, Message<*>) -> Nothing = mock { }
+
+        val result = target.mapSize(fieldNumber, map, createEntry)
+
+        assertThat(result).isEqualTo(protoSize + sizeOfProtoSize + 1) // sizeof fieldNumber
+    }
+
+    @Test
+    fun `int64Size should call uInt64Size`() {
+        val input = 1L
+        target = spy(target)
+
+        target.int64Size(input)
+
+        verify(target).uInt64Size(input)
+    }
+
+
+    @Test
+    fun `bytesSize should call uInt32Size with the array size`() {
+        val size = 10
+        val input = ByteArray(size)
+        target = spy(target)
+
+        target.bytesSize(input)
+
+        verify(target).uInt32Size(size)
+    }
+
+    @Test
+    fun `bytesSize should return uInt32Size of the array size + array size`() {
+        val size = 10
+        val tagSize = 1 // size is less than 127
+        val input = ByteArray(size)
+
+        val result = target.bytesSize(input)
+
+        assertThat(result).isEqualTo(size + tagSize)
+    }
+
+    @Test
+    fun `sInt32Size should call uInt32Size with zigzag encoded input`() {
+        val input = 10
+        val zigZagEncoded = (input shl 1) xor (input shr 31)
+        target = spy(target)
+
+        target.sInt32Size(input)
+
+        verify(target).uInt32Size(zigZagEncoded)
+    }
+
+    @Test
+    fun `sInt64Size should call uInt64Size with zigzag encoded input`() {
+        val input = 10L
+        val zigZagEncoded = (input shl 1) xor (input shr 63)
+        target = spy(target)
+
+        target.sInt64Size(input)
+
+        verify(target).uInt64Size(zigZagEncoded)
+    }
+
+    @Test
+    fun `doubleSize should equal 8`() {
+        assertThat(target.doubleSize()).isEqualTo(8)
+    }
+
+    @Test
+    fun `floatSize should equal 4`() {
+        assertThat(target.floatSize()).isEqualTo(4)
+    }
+
+    @Test
+    fun `fixed32Size should equal 4`() {
+        assertThat(target.fixed32Size()).isEqualTo(4)
+    }
+
+    @Test
+    fun `fixed64Size should equal 8`() {
+        assertThat(target.fixed64Size()).isEqualTo(8)
+    }
+
+    @Test
+    fun `sFixed32Size should equal 4`() {
+        assertThat(target.sFixed32Size()).isEqualTo(4)
+    }
+
+    @Test
+    fun `sFixed64Size should equal 8`() {
+        assertThat(target.sFixed64Size()).isEqualTo(8)
+    }
+
+    @Test
+    fun `boolSize should equal 1`() {
+        assertThat(target.boolSize()).isEqualTo(1)
+    }
+
+    @Test
+    fun stringSize() {
+    }
+}

--- a/runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
closes #35

In order to remove the dependency on pbandk, reimplement the Sizer locally, and add tests

**Note**
This is a breaking change - if you are building from master you must update both the runtime and the code generator, otherwise you will get compilation errors