### PR TITLE
Replace pbandk ByteArr with local implementation

### DIFF
--- a/library/src/main/kotlin/jp/co/panpanini/TypeExtensions.kt
+++ b/library/src/main/kotlin/jp/co/panpanini/TypeExtensions.kt
@@ -35,7 +35,7 @@ val File.Field.Type.wireFormat get() = when (this) {
 
 val File.Field.Type.standardTypeName get() = when (this) {
     File.Field.Type.BOOL -> Boolean::class.asTypeName()
-    File.Field.Type.BYTES -> pbandk.ByteArr::class.asTypeName()
+    File.Field.Type.BYTES -> ByteArr::class.asTypeName()
     File.Field.Type.DOUBLE -> Double::class.asTypeName()
     File.Field.Type.ENUM -> error("No standard type name for enums")
     File.Field.Type.FIXED32 -> Int::class.asTypeName()
@@ -55,7 +55,7 @@ val File.Field.Type.standardTypeName get() = when (this) {
 
 val File.Field.Type.defaultValue get() = when (this) {
     File.Field.Type.BOOL -> "false"
-    File.Field.Type.BYTES -> "pbandk.ByteArr.empty"
+    File.Field.Type.BYTES -> "ByteArr()"
     File.Field.Type.DOUBLE -> "0.0"
     File.Field.Type.ENUM -> error("No generic default value for enums")
     File.Field.Type.FIXED32, File.Field.Type.INT32, File.Field.Type.SFIXED32,

--- a/library/src/test/resources/kotlin/OneOfTest.kt
+++ b/library/src/test/resources/kotlin/OneOfTest.kt
@@ -3,6 +3,7 @@
 package api
 
 import java.io.Serializable
+import jp.co.panpanini.ByteArr
 import jp.co.panpanini.Marshaller
 import jp.co.panpanini.Message
 import jp.co.panpanini.UnknownField
@@ -17,7 +18,6 @@ import kotlin.String
 import kotlin.collections.Map
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
-import pbandk.ByteArr
 
 data class OneOfTest(@JvmField val oneofField: OneofField = OneofField.NotSet, val unknownFields:
         Map<Int, UnknownField> = emptyMap()) : Message<OneOfTest>, Serializable {
@@ -126,7 +126,7 @@ data class OneOfTest(@JvmField val oneofField: OneofField = OneofField.NotSet, v
 
         data class OneofString(val oneofString: String = "") : OneofField()
 
-        data class OneofBytes(val oneofBytes: ByteArr = pbandk.ByteArr.empty) : OneofField()
+        data class OneofBytes(val oneofBytes: ByteArr = ByteArr()) : OneofField()
 
         data class OneofBool(val oneofBool: Boolean = false) : OneofField()
 

--- a/runtime/src/main/kotlin/ByteArr.kt
+++ b/runtime/src/main/kotlin/ByteArr.kt
@@ -1,0 +1,7 @@
+package jp.co.panpanini
+
+class ByteArr(val array: ByteArray = ByteArray(0)) {
+    override fun equals(other: Any?) = other is ByteArr && array.contentEquals(other.array)
+    override fun hashCode() = array.contentHashCode()
+    override fun toString() = array.contentToString()
+}

--- a/runtime/src/main/kotlin/Marshaller.kt
+++ b/runtime/src/main/kotlin/Marshaller.kt
@@ -1,7 +1,6 @@
 package jp.co.panpanini
 
 import com.google.protobuf.CodedOutputStream
-import pbandk.ByteArr
 
 class Marshaller(private val stream: CodedOutputStream, private val bytes: ByteArray? = null) {
 

--- a/runtime/src/main/kotlin/Sizer.kt
+++ b/runtime/src/main/kotlin/Sizer.kt
@@ -1,7 +1,6 @@
 package jp.co.panpanini
 
 import com.google.protobuf.CodedOutputStream
-import pbandk.ByteArr
 
 object Sizer {
     fun tagSize(fieldNum: Int): Int {

--- a/runtime/src/main/kotlin/UnknownField.kt
+++ b/runtime/src/main/kotlin/UnknownField.kt
@@ -1,7 +1,5 @@
 package jp.co.panpanini
 
-import pbandk.ByteArr
-import pbandk.Sizer
 
 class UnknownField(val fieldNum: Int, val value: Value) {
     constructor(fieldNum: Int, value: Long, fixed: Boolean = false) :

--- a/runtime/src/main/kotlin/Unmarshaller.kt
+++ b/runtime/src/main/kotlin/Unmarshaller.kt
@@ -2,7 +2,6 @@ package jp.co.panpanini
 
 import com.google.protobuf.CodedInputStream
 import com.google.protobuf.WireFormat
-import pbandk.ByteArr
 
 class Unmarshaller(private val stream: CodedInputStream, private val discardUnknownFields: Boolean = false) {
     private var currentUnknownFields = if (discardUnknownFields) null else mutableMapOf<Int, UnknownField>()

--- a/runtime/src/test/kotlin/MarshallerTest.kt
+++ b/runtime/src/test/kotlin/MarshallerTest.kt
@@ -3,11 +3,11 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import jp.co.panpanini.ByteArr
 import jp.co.panpanini.Marshaller
 import jp.co.panpanini.Message
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import pbandk.ByteArr
 
 class MarshallerTest {
 


### PR DESCRIPTION
closes #41 

ByteArr class is to implement equals & hash, which are not implemented by Java arrays