### PR TITLE
Use Message.Enum for sizing enum

### DIFF
--- a/runtime/src/main/kotlin/Sizer.kt
+++ b/runtime/src/main/kotlin/Sizer.kt
@@ -21,8 +21,8 @@ object Sizer {
         }
     }
 
-    fun enumSize(value: Enum<*>): Int {
-        return int32Size(value.ordinal)
+    fun enumSize(value: Message.Enum): Int {
+        return int32Size(value.value)
     }
 
     fun messageSize(value: Message<*>) : Int {

--- a/runtime/src/test/kotlin/SizerTest.kt
+++ b/runtime/src/test/kotlin/SizerTest.kt
@@ -102,14 +102,14 @@ class SizerTest {
 
     @Test
     fun `enumSize should call int32Size`() {
-        val input: Enum<*> = mock {
-            whenever(mock.ordinal).thenReturn(1)
+        val input: Message.Enum = mock {
+            whenever(mock.value).thenReturn(1)
         }
         target = spy(target)
 
         target.enumSize(input)
 
-        verify(target).int32Size(input.ordinal)
+        verify(target).int32Size(input.value)
     }
 
     @Test


### PR DESCRIPTION
When writing an `Enum` to the wire, we use the Enum `value`, not the ordinal. 

Sizing should also take this into account, and size according to the value, not ordinal